### PR TITLE
Geo distance sort

### DIFF
--- a/lib/searchfilter.go
+++ b/lib/searchfilter.go
@@ -197,8 +197,8 @@ type RangeFilter struct {
 }
 
 type GeoLocation struct {
-	Latitude  float32 `json:"lat"`
-	Longitude float32 `json:"lon"`
+	Latitude  float64 `json:"lat"`
+	Longitude float64 `json:"lon"`
 }
 
 type GeoField struct {
@@ -270,7 +270,7 @@ func (f *FilterOp) GeoDistanceRange(from string, to string, fields ...GeoField) 
 }
 
 // Helper to create values for the GeoDistance filters
-func NewGeoField(field string, latitude float32, longitude float32) GeoField {
+func NewGeoField(field string, latitude float64, longitude float64) GeoField {
 	return GeoField{
 		GeoLocation: GeoLocation{Latitude: latitude, Longitude: longitude},
 		Field:       field}

--- a/lib/searchsort.go
+++ b/lib/searchsort.go
@@ -26,10 +26,15 @@ func Sort(field string) *SortDsl {
 	return &SortDsl{Name: field}
 }
 
+func GeoDistanceSort(field interface{}) *SortDsl {
+	return &SortDsl{GeoDistance: field}
+}
+
 type SortBody []interface{}
 type SortDsl struct {
-	Name   string
-	IsDesc bool
+	Name        string
+	IsDesc      bool
+	GeoDistance interface{}
 }
 
 func (s *SortDsl) Desc() *SortDsl {
@@ -42,6 +47,9 @@ func (s *SortDsl) Asc() *SortDsl {
 }
 
 func (s *SortDsl) MarshalJSON() ([]byte, error) {
+	if s.GeoDistance != nil {
+		return json.Marshal(map[string]interface{}{"_geo_distance": s.GeoDistance})
+	}
 	if s.IsDesc {
 		return json.Marshal(map[string]string{s.Name: "desc"})
 	}


### PR DESCRIPTION
- 距離でソートするための実装を追加しました。
- 値を渡す際のfloat64からfloat32への変換が面倒なのと、float64からfloat32に変換したときにlatitude, longitudeの値の微小な変化が気になったのでlatitudeとlongitudeの型をfloat64に変えました。

参考
https://www.elastic.co/guide/en/elasticsearch/guide/current/sorting-by-distance.html